### PR TITLE
Update cv2 usage

### DIFF
--- a/PyOpenCV/pygazetracker/generic.py
+++ b/PyOpenCV/pygazetracker/generic.py
@@ -755,7 +755,7 @@ def _crop_face(frame, face_cascade, minsize=(30, 30)):
 		scaleFactor=1.1,
 		minNeighbors=5,
 		minSize=minsize,
-		flags = cv2.cv.CV_HAAR_SCALE_IMAGE
+		flags = cv2.CASCADE_SCALE_IMAGE
 		)
 	
 	# Find out what the largest face is (this is assumed to be the


### PR DESCRIPTION
The line "flags = cv2.cv.CV_HAAR_SCALE_IMAGE" was throwing an error. This is most likely because the updated Python OpenCV library no longer supports importing the legacy cv module. For more information, please visit the link below:

https://stackoverflow.com/questions/36242860/attribute-error-while-using-opencv-for-face-recognition